### PR TITLE
Update rds_s3.yaml

### DIFF
--- a/infra/rds_s3.yaml
+++ b/infra/rds_s3.yaml
@@ -59,7 +59,7 @@ Resources:
     Properties:
       EnableIAMDatabaseAuthentication: true
       AllocatedStorage: 20
-      DBInstanceClass: db.t2.micro
+      DBInstanceClass: db.t3.small
       Engine: postgres
       MasterUsername: !Sub '{{resolve:secretsmanager:${MyRDSSecret}::username}}'
       MasterUserPassword: !Sub '{{resolve:secretsmanager:${MyRDSSecret}::password}}'


### PR DESCRIPTION
This instance type is not available for postgres DBs. See here: https://repost.aws/questions/QUFTU3sWQwR4GC1N0VwjtBAw/rds-does-not-support-creating-a-db-instance